### PR TITLE
feat(arfur-build): allow building on Windows

### DIFF
--- a/arfur-build/src/runner.rs
+++ b/arfur-build/src/runner.rs
@@ -1,4 +1,6 @@
-use std::{fs, io::Cursor, os::unix::fs::PermissionsExt, path::Path};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::{fs, io::Cursor, path::Path};
 
 use crate::library::Library;
 
@@ -122,10 +124,16 @@ impl<'a, T: Library> Runner<'a, T> {
             .join("athena")
             .join("shared");
 
-        fs::set_permissions(&dynamic_library_dir, fs::Permissions::from_mode(0o755))?;
+        #[cfg(unix)]
+        {
+            fs::set_permissions(&dynamic_library_dir, fs::Permissions::from_mode(0o755))?;
+        }
         for file in fs::read_dir(&dynamic_library_dir)? {
             let file = file?;
-            fs::set_permissions(&file.path(), fs::Permissions::from_mode(0o755))?;
+            #[cfg(unix)]
+            {
+                fs::set_permissions(&file.path(), fs::Permissions::from_mode(0o755))?;
+            }
 
             if file.file_name().to_str().unwrap().ends_with(".debug") {
                 // If it's a debug file, just delete it.


### PR DESCRIPTION
This is all I needed to change to get Arfur building on a Windows machine (without bindgen at least - I tried making more changes to get bindgen working as well, but ran into linking errors in arfur-rev and ultimately gave up).

Whatever system is used to deploy these files to the rio should make sure the files are deployed with full permissions (`cargo-rio` already does this, `cargo-frc` doesn't support Windows anyway). This is probably the best we can do on Windows since the file permissions work differently.